### PR TITLE
Fix #14 "Cannot LDFTN a non-final virtual method"

### DIFF
--- a/AssemblyToProcess/AssemblyToProcess.csproj
+++ b/AssemblyToProcess/AssemblyToProcess.csproj
@@ -62,6 +62,7 @@
     <Compile Include="EnsureNewToOverrideWithInterface.cs">
       <SubType>Code</SubType>
     </Compile>
+    <Compile Include="CallVirtualizedMethodInClassNestedInGenericClass.cs" />
     <Compile Include="IInterface.cs">
       <SubType>Code</SubType>
     </Compile>

--- a/AssemblyToProcess/CallVirtualizedMethodInClassNestedInGenericClass.cs
+++ b/AssemblyToProcess/CallVirtualizedMethodInClassNestedInGenericClass.cs
@@ -1,0 +1,36 @@
+﻿using System;
+
+namespace VirtuosityAbstractClassLDFTNIssue
+{
+    public interface IChannelBase
+    {
+        AsyncResultBase BeginCreateSession(AsyncCallback asyncCallback);
+    }
+
+    public class RegistrationChannel<TChannel>
+        where TChannel : IChannelBase
+    {
+        protected class WcfChannelAsyncResult : AsyncResultBase
+        {
+            public void OnOperationCompleted(IAsyncResult ar)
+            {
+            }
+        }
+
+        public AsyncResultBase DoSomething(AsyncCallback callback)
+        {
+            var arb = new WcfChannelAsyncResult();
+
+            arb.InnerResult = arb.Channel.BeginCreateSession(arb.OnOperationCompleted);
+
+            return arb;
+        }
+    }
+
+    public abstract class AsyncResultBase
+    {
+        public AsyncResultBase InnerResult { get; set; }
+
+        public IChannelBase Channel { get; set; }
+    }
+}

--- a/CommonAssemblyInfo.cs
+++ b/CommonAssemblyInfo.cs
@@ -2,5 +2,5 @@
 
 [assembly: AssemblyTitle("Virtuosity")]
 [assembly: AssemblyProduct("Virtuosity")]
-[assembly: AssemblyVersion("1.20.0")]
-[assembly: AssemblyFileVersion("1.20.0")]
+[assembly: AssemblyVersion("1.20.1")]
+[assembly: AssemblyFileVersion("1.20.1")]

--- a/Fody/Fody.csproj
+++ b/Fody/Fody.csproj
@@ -54,20 +54,16 @@
     <Reference Include="Microsoft.Build.Utilities.v4.0" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="Mono.Cecil, Version=0.10.0.0, Culture=neutral, PublicKeyToken=50cebf1cceb9d05e, processorArchitecture=MSIL">
-      <HintPath>..\packages\FodyCecil.2.0.0\lib\net40\Mono.Cecil.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\packages\FodyCecil.2.1.2\lib\net40\Mono.Cecil.dll</HintPath>
     </Reference>
     <Reference Include="Mono.Cecil.Mdb, Version=0.10.0.0, Culture=neutral, PublicKeyToken=50cebf1cceb9d05e, processorArchitecture=MSIL">
-      <HintPath>..\packages\FodyCecil.2.0.0\lib\net40\Mono.Cecil.Mdb.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\packages\FodyCecil.2.1.2\lib\net40\Mono.Cecil.Mdb.dll</HintPath>
     </Reference>
     <Reference Include="Mono.Cecil.Pdb, Version=0.10.0.0, Culture=neutral, PublicKeyToken=50cebf1cceb9d05e, processorArchitecture=MSIL">
-      <HintPath>..\packages\FodyCecil.2.0.0\lib\net40\Mono.Cecil.Pdb.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\packages\FodyCecil.2.1.2\lib\net40\Mono.Cecil.Pdb.dll</HintPath>
     </Reference>
     <Reference Include="Mono.Cecil.Rocks, Version=0.10.0.0, Culture=neutral, PublicKeyToken=50cebf1cceb9d05e, processorArchitecture=MSIL">
-      <HintPath>..\packages\FodyCecil.2.0.0\lib\net40\Mono.Cecil.Rocks.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\packages\FodyCecil.2.1.2\lib\net40\Mono.Cecil.Rocks.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -111,11 +107,11 @@
     <Copy SourceFiles="$(ProjectDir)NugetAssets\Fody_ToBeDeleted.txt" DestinationFolder="$(SolutionDir)NuGetBuild\Content" />
     <PepitaPackage.CreatePackageTask NuGetBuildDirectory="$(SolutionDir)NuGetBuild" MetadataAssembly="$(OutputPath)Virtuosity.Fody.dll" />
   </Target>
+  <Import Project="..\packages\PepitaPackage.1.21.6\build\PepitaPackage.targets" Condition="Exists('..\packages\PepitaPackage.1.21.6\build\PepitaPackage.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\PepitaPackage.1.21.4\build\PepitaPackage.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\PepitaPackage.1.21.4\build\PepitaPackage.targets'))" />
+    <Error Condition="!Exists('..\packages\PepitaPackage.1.21.6\build\PepitaPackage.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\PepitaPackage.1.21.6\build\PepitaPackage.targets'))" />
   </Target>
-  <Import Project="..\packages\PepitaPackage.1.21.4\build\PepitaPackage.targets" Condition="Exists('..\packages\PepitaPackage.1.21.4\build\PepitaPackage.targets')" />
 </Project>

--- a/Fody/packages.config
+++ b/Fody/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="FodyCecil" version="2.0.0" targetFramework="net452" developmentDependency="true" />
-  <package id="PepitaPackage" version="1.21.4" targetFramework="net45" developmentDependency="true" />
+  <package id="FodyCecil" version="2.1.2" targetFramework="net452" developmentDependency="true" />
+  <package id="PepitaPackage" version="1.21.6" targetFramework="net452" developmentDependency="true" />
 </packages>

--- a/Templates/CallVirtualizedMethodInClassNestedInGenericClass.cs
+++ b/Templates/CallVirtualizedMethodInClassNestedInGenericClass.cs
@@ -1,0 +1,36 @@
+﻿using System;
+
+namespace VirtuosityAbstractClassLDFTNIssue
+{
+    public interface IChannelBase
+    {
+        AsyncResultBase BeginCreateSession(AsyncCallback asyncCallback);
+    }
+
+    public class RegistrationChannel<TChannel>
+        where TChannel : IChannelBase
+    {
+        protected class WcfChannelAsyncResult : AsyncResultBase
+        {
+            public virtual void OnOperationCompleted(IAsyncResult ar)
+            {
+            }
+        }
+
+        public AsyncResultBase DoSomething(AsyncCallback callback)
+        {
+            var arb = new WcfChannelAsyncResult();
+
+            arb.InnerResult = arb.Channel.BeginCreateSession(arb.OnOperationCompleted);
+
+            return arb;
+        }
+    }
+
+    public abstract class AsyncResultBase
+    {
+        public AsyncResultBase InnerResult { get; set; }
+
+        public IChannelBase Channel { get; set; }
+    }
+}

--- a/Templates/Templates.csproj
+++ b/Templates/Templates.csproj
@@ -54,6 +54,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AbstractClass.cs" />
+    <Compile Include="CallVirtualizedMethodInClassNestedInGenericClass.cs" />
     <Compile Include="MethodRedirectionBaseClass.cs" />
     <Compile Include="MethodRedirectionChildClass.cs" />
     <Compile Include="MethodsAndPropertiesAreMarkedAsVirtualClass.cs" />

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -32,24 +32,19 @@
   <ItemGroup>
     <Reference Include="Microsoft.Build.Utilities.v4.0" />
     <Reference Include="Mono.Cecil, Version=0.10.0.0, Culture=neutral, PublicKeyToken=50cebf1cceb9d05e, processorArchitecture=MSIL">
-      <HintPath>..\packages\FodyCecil.2.0.0\lib\net40\Mono.Cecil.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\packages\FodyCecil.2.1.2\lib\net40\Mono.Cecil.dll</HintPath>
     </Reference>
     <Reference Include="Mono.Cecil.Mdb, Version=0.10.0.0, Culture=neutral, PublicKeyToken=50cebf1cceb9d05e, processorArchitecture=MSIL">
-      <HintPath>..\packages\FodyCecil.2.0.0\lib\net40\Mono.Cecil.Mdb.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\packages\FodyCecil.2.1.2\lib\net40\Mono.Cecil.Mdb.dll</HintPath>
     </Reference>
     <Reference Include="Mono.Cecil.Pdb, Version=0.10.0.0, Culture=neutral, PublicKeyToken=50cebf1cceb9d05e, processorArchitecture=MSIL">
-      <HintPath>..\packages\FodyCecil.2.0.0\lib\net40\Mono.Cecil.Pdb.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\packages\FodyCecil.2.1.2\lib\net40\Mono.Cecil.Pdb.dll</HintPath>
     </Reference>
     <Reference Include="Mono.Cecil.Rocks, Version=0.10.0.0, Culture=neutral, PublicKeyToken=50cebf1cceb9d05e, processorArchitecture=MSIL">
-      <HintPath>..\packages\FodyCecil.2.0.0\lib\net40\Mono.Cecil.Rocks.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\packages\FodyCecil.2.1.2\lib\net40\Mono.Cecil.Rocks.dll</HintPath>
     </Reference>
-    <Reference Include="nunit.framework, Version=3.6.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
-      <HintPath>..\packages\NUnit.3.6.1\lib\net45\nunit.framework.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="nunit.framework, Version=3.8.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnit.3.8.1\lib\net45\nunit.framework.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -72,13 +67,13 @@
     <Compile Include="VirtualTests.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="packages.config" />
-  </ItemGroup>
-  <ItemGroup>
     <ProjectReference Include="..\Fody\Fody.csproj">
       <Project>{C3578A7B-09A6-4444-9383-0DEAFA4958BD}</Project>
       <Name>Fody</Name>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -30,6 +30,7 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Microsoft.Build.Utilities.v4.0" />
     <Reference Include="Mono.Cecil, Version=0.10.0.0, Culture=neutral, PublicKeyToken=50cebf1cceb9d05e, processorArchitecture=MSIL">
       <HintPath>..\packages\FodyCecil.2.0.0\lib\net40\Mono.Cecil.dll</HintPath>
       <Private>True</Private>

--- a/Tests/Verifier.cs
+++ b/Tests/Verifier.cs
@@ -1,26 +1,44 @@
-﻿using System;
-using System.Diagnostics;
+﻿using System.Diagnostics;
 using System.IO;
+using System.Linq;
 using System.Text.RegularExpressions;
+using Microsoft.Build.Utilities;
 using NUnit.Framework;
 
 public static class Verifier
 {
+    static string exePath;
+    static bool peverifyFound;
+
+    static Verifier()
+    {
+        var sdkPath = Path.GetFullPath(Path.Combine(ToolLocationHelper.GetPathToDotNetFrameworkSdk(TargetDotNetFrameworkVersion.VersionLatest), "..\\.."));
+        exePath = Directory.GetFiles(sdkPath, "peverify.exe", SearchOption.AllDirectories).LastOrDefault();
+
+        peverifyFound = File.Exists(exePath);
+        if (!peverifyFound)
+        {
+#if(!DEBUG)
+            throw new System.Exception("Could not find PEVerify");
+#endif
+        }
+    }
     public static void Verify(string beforeAssemblyPath, string afterAssemblyPath)
     {
+        if (!peverifyFound)
+        {
+            return;
+        }
+        Debug.WriteLine(afterAssemblyPath);
         var before = Validate(beforeAssemblyPath);
         var after = Validate(afterAssemblyPath);
         var message = $"Failed processing {Path.GetFileName(afterAssemblyPath)}\r\n{after}";
         Assert.AreEqual(TrimLineNumbers(before), TrimLineNumbers(after), message);
     }
 
-    static string Validate(string assemblyPath2)
+    public static string Validate(string assemblyPath2)
     {
-        var exePath = GetPathToPEVerify();
-        if (!File.Exists(exePath))
-        {
-            return string.Empty;
-        }
+
         var process = Process.Start(new ProcessStartInfo(exePath, "\"" + assemblyPath2 + "\"")
         {
             RedirectStandardOutput = true,
@@ -30,17 +48,6 @@ public static class Verifier
 
         process.WaitForExit(10000);
         return process.StandardOutput.ReadToEnd().Trim().Replace(assemblyPath2, "");
-    }
-
-    static string GetPathToPEVerify()
-    {
-        var exePath = Environment.ExpandEnvironmentVariables(@"%programfiles(x86)%\Microsoft SDKs\Windows\v7.0A\Bin\NETFX 4.0 Tools\PEVerify.exe");
-
-        if (!File.Exists(exePath))
-        {
-            exePath = Environment.ExpandEnvironmentVariables(@"%programfiles(x86)%\Microsoft SDKs\Windows\v8.0A\Bin\NETFX 4.0 Tools\PEVerify.exe");
-        }
-        return exePath;
     }
 
     static string TrimLineNumbers(string foo)

--- a/Tests/packages.config
+++ b/Tests/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="FodyCecil" version="2.0.0" targetFramework="net452" developmentDependency="true" />
-  <package id="NUnit" version="3.6.1" targetFramework="net452" />
+  <package id="FodyCecil" version="2.1.2" targetFramework="net452" developmentDependency="true" />
+  <package id="NUnit" version="3.8.1" targetFramework="net452" />
 </packages>


### PR DESCRIPTION
- includes new test code .. which failed before the fix ;-)
- copied PEverify code from PropertyChanged.Fody - so it works with new VS/.net installations, too

- locally tested with the problematic code
- locally tested with our product-code, where we MOQ all the classes.

- updated nuget packages to latest non-pre versions
- bumped version from 1.20.0 to 1.20.1

Specific logic-change can be found in: FunctionPointerConverter.cs method  `DetermineMethodTo_Ldvirtftn`.

I refactored the logic in the `for (var index = 0; index < instructions.Count; index++)` loop a little bit because with the two `if`s - checks for operand matching virtualised methods -  it became a bit complicated.