### PR TITLE
Set ProduceReferenceAssembly to false by default

### DIFF
--- a/Virtuosity/Virtuosity.csproj
+++ b/Virtuosity/Virtuosity.csproj
@@ -11,6 +11,7 @@
     <PackageIconUrl>https://raw.githubusercontent.com/Fody/Virtuosity/master/package_icon.png</PackageIconUrl>
     <PackageProjectUrl>https://github.com/Fody/Virtuosity</PackageProjectUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <WeaverPropsFile>Weaver.props</WeaverPropsFile>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Fody" Version="6.3.0" PrivateAssets="none" />

--- a/Virtuosity/Weaver.props
+++ b/Virtuosity/Weaver.props
@@ -1,0 +1,8 @@
+﻿<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <ProduceReferenceAssembly>false</ProduceReferenceAssembly>
+  </PropertyGroup>
+  <ItemGroup>
+    <WeaverFiles Include="$(MsBuildThisFileDirectory)..\weaver\$(MSBuildThisFileName).dll" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
This is a quick fix for #294, it implements solution 2 from [this post](https://github.com/Fody/Virtuosity/issues/294#issuecomment-778103823).

I don't really like having to duplicate the code of the `WeaverFiles` item from FodyPackaging, but I currently don't see a better way - tell me if you have a better idea.

This kind of patch may be useful for other weavers as well.
